### PR TITLE
Feature/refactor recipe filtering

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:lunch_me/data/dao/recipe_dao.dart';
 import 'package:lunch_me/data/dao/tag_dao.dart';
 import 'package:lunch_me/data/dao/taggroup_dao.dart';
+import 'package:lunch_me/model/recipe_filters.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -75,6 +76,10 @@ class MyDatabase extends _$MyDatabase {
       var tags = entry.value.map((e) => e.tag).whereType<Tag>().toList();
       return RecipeWithTags(recipe, tags);
     }).toList();
+  }
+
+  Future<List<RecipeWithTags>> filterRecipes(List<RecipeFilter> filterList) async {
+    return getAllRecipeWithTags();
   }
 
   Future<List<RecipeWithTags>> filterRecipeByTags(List<int> tagIds) async {

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -150,55 +150,7 @@ class MyDatabase extends _$MyDatabase {
       }
     });
 
-    /*
-
-    result.sort((a, b) => a.tags.length.compareTo(b.tags.length));  // TODO sorting
-
-    return result.reversed.toList();
-
-
-     */
-
     return result;
-  }
-
-
-
-
-
-  Future<List<RecipeWithTags>> filterRecipeByTags(List<int> tagIds) async {
-    if(tagIds.isEmpty){
-      return getAllRecipeWithTags();
-    }
-
-    var recipeIds = await _getRecipeIdsHavingTags(tagIds);
-
-    var query = select(recipes).join([
-      leftOuterJoin(recipeTags, recipeTags.recipe.equalsExp(recipes.id)),
-      leftOuterJoin(tags, tags.id.equalsExp(recipeTags.tag)),
-    ])
-      ..where(recipes.id.isIn(recipeIds))
-      ..orderBy([OrderingTerm(expression: recipes.name)]);
-
-    var queryResult = query.map((row) {
-      var recipe = row.readTable(recipes);
-      var tag = row.readTableOrNull(tags);
-
-      return _RecipeWithTag(recipe, tag);
-    });
-
-    var tagsGroupedByRecipe =
-        (await queryResult.get()).groupListsBy((element) => element.recipe);
-
-    var result = tagsGroupedByRecipe.entries.map((entry) {
-      var recipe = entry.key;
-      var tags = entry.value.map((e) => e.tag).whereType<Tag>().toList();
-      return RecipeWithTags(recipe, tags);
-    }).toList();
-
-    result.sort((a, b) => a.tags.length.compareTo(b.tags.length));
-
-    return result.reversed.toList();
   }
 
   Future<List<int>> _getRecipeIdsHavingTags(List<int> tagIds) async {

--- a/lib/model/recipe_filters.dart
+++ b/lib/model/recipe_filters.dart
@@ -3,13 +3,27 @@ import 'dart:collection';
 import 'package:flutter/material.dart';
 
 class RecipeFilters extends ChangeNotifier {
-  final List<int> _tagIds = [];
+  final List<RecipeFilter> _filterList = [];
 
-  UnmodifiableListView<int> get tagIds => UnmodifiableListView(_tagIds);
+  UnmodifiableListView<RecipeFilter> get filter => UnmodifiableListView(_filterList);
 
-  void setTagFilters(List<int> tagIds) {
-    _tagIds.clear();
-    _tagIds.addAll(tagIds);
+  void setFilter(List<RecipeFilter> filter) {
+    _filterList.clear();
+    _filterList.addAll(filter);
     notifyListeners();
   }
+}
+
+class RecipeFilter {
+  final int tagGroup;
+  final bool allMatch;
+  final List<int> tags;
+
+  RecipeFilter(this.tagGroup, this.allMatch, this.tags);
+
+  @override
+  int get hashCode => tagGroup.hashCode;
+
+  @override
+  bool operator ==(Object other) => other is RecipeFilter && other.runtimeType == runtimeType && other.tagGroup == tagGroup;
 }

--- a/lib/pages/home/widgets/recipe_list.dart
+++ b/lib/pages/home/widgets/recipe_list.dart
@@ -121,7 +121,7 @@ class _RecipeListState extends State<RecipeList> {
     return Consumer<RecipeFilters>(
       builder: (context, recipeFilters, child) {
         return FutureBuilder<List<RecipeWithTags>>(
-            future: database.filterRecipeByTags(recipeFilters.tagIds),
+            future: database.filterRecipes(recipeFilters.filter),
             builder: (BuildContext context, AsyncSnapshot recipesSnapshot) {
               return recipesSnapshot.connectionState == ConnectionState.waiting
                   ? buildCustomLoader()

--- a/lib/pages/home/widgets/tag_group_list.dart
+++ b/lib/pages/home/widgets/tag_group_list.dart
@@ -83,13 +83,22 @@ class _TagGroupListState extends State<TagGroupList> {
   }
 
   bool _isTagSelected(List<RecipeFilter> filterList, Tag tag) {
-    filterList.firstWhereOrNull((filter) => filter.tags.contains(tag.id)) != null;
-    return true;
+    return filterList.firstWhereOrNull((filter) => filter.tags.contains(tag.id)) != null;
   }
 
   void _addRecipeFilter(List<RecipeFilter> filterList, bool allMatch, Tag tag) {
-    var filter = filterList.firstWhereOrNull((filter) => filter.tagGroup == tag.tagGroup) ?? RecipeFilter(tag.tagGroup, allMatch, []);
+    var filter = filterList.firstWhereOrNull((filter) => filter.tagGroup == tag.tagGroup);
+    bool firstTimeFilter = false;
+    if (filter == null) {
+      filter = RecipeFilter(tag.tagGroup, allMatch, []);
+      firstTimeFilter = true;
+    }
+
     filter.tags.add(tag.id);
+
+    if (firstTimeFilter) {
+      filterList.add(filter);
+    }
   }
 
   void _removeRecipeFilter(List<RecipeFilter> filterList, Tag tag) {

--- a/lib/pages/home/widgets/tag_group_list.dart
+++ b/lib/pages/home/widgets/tag_group_list.dart
@@ -1,11 +1,11 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:lunch_me/model/recipe_filters.dart';
-import 'package:provider/provider.dart';
-
 import 'package:lunch_me/data/database.dart';
-import 'package:lunch_me/widgets/error_message.dart';
+import 'package:lunch_me/model/recipe_filters.dart';
 import 'package:lunch_me/widgets/custom_loader.dart';
+import 'package:lunch_me/widgets/error_message.dart';
+import 'package:provider/provider.dart';
 
 class TagGroupList extends StatefulWidget {
   const TagGroupList({super.key});
@@ -18,7 +18,7 @@ class _TagGroupListState extends State<TagGroupList> {
   late final Stream<List<TagGroupWithTags>> _watchTagGroupsWithTags;
   late final MyDatabase database;
 
-  final List<int> _selectedTags = <int>[];
+  final List<RecipeFilter> _selectedTags = <RecipeFilter>[];
 
   void initializeData() {
     database = Provider.of<MyDatabase>(context, listen: false);
@@ -61,19 +61,17 @@ class _TagGroupListState extends State<TagGroupList> {
                   padding: const EdgeInsets.all(4.0),
                   child: FilterChip(
                     label: Text(tag.label),
-                    selected: _selectedTags.contains(tag.id),
+                    selected: _isTagSelected(_selectedTags, tag),
                     backgroundColor: Colors.blueGrey.withAlpha(50),
                     selectedColor: Colors.lime,
                     onSelected: (bool value) {
                       setState(() {
                         if (value) {
-                          _selectedTags.add(tag.id);
+                          _addRecipeFilter(_selectedTags, true, tag);
                         } else {
-                          _selectedTags.removeWhere((int tagId) {
-                            return tagId == tag.id;
-                          });
+                          _removeRecipeFilter(_selectedTags, tag);
                         }
-                        Provider.of<RecipeFilters>(context, listen: false).setTagFilters(_selectedTags);
+                        Provider.of<RecipeFilters>(context, listen: false).setFilter(_selectedTags);
                       });
                     },
                   ),
@@ -82,6 +80,21 @@ class _TagGroupListState extends State<TagGroupList> {
             )
           ],
         ));
+  }
+
+  bool _isTagSelected(List<RecipeFilter> filterList, Tag tag) {
+    filterList.firstWhereOrNull((filter) => filter.tags.contains(tag.id)) != null;
+    return true;
+  }
+
+  void _addRecipeFilter(List<RecipeFilter> filterList, bool allMatch, Tag tag) {
+    var filter = filterList.firstWhereOrNull((filter) => filter.tagGroup == tag.tagGroup) ?? RecipeFilter(tag.tagGroup, allMatch, []);
+    filter.tags.add(tag.id);
+  }
+
+  void _removeRecipeFilter(List<RecipeFilter> filterList, Tag tag) {
+    var filter = filterList.firstWhere((filter) => filter.tagGroup == tag.tagGroup);
+    filter.tags.remove(tag.id);
   }
 
   @override

--- a/test/data/database_test.dart
+++ b/test/data/database_test.dart
@@ -1,5 +1,8 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lunch_me/data/tables.dart';
+import 'package:lunch_me/model/recipe_filters.dart';
 
 import 'flutter_test_config.dart';
 
@@ -44,40 +47,126 @@ void main() {
     expect(actual[2].tags.map((e) => e.id), containsAllInOrder([6]));
   });
 
-  test('filter recipes by tags should return empty list', () async {
+  test('filter recipes should return all recipes when no tag is selected', () async {
     // when
-    var actual = await testDatabase.filterRecipeByTags([1]);
+    var recipeWithTags = await testDatabase.filterRecipes([]);
 
     // then
-    expect(actual.length, 0);
+    expect(recipeWithTags.length, 3);
+    expect(recipeWithTags.map((e) => e.recipe.name), containsAllInOrder(["recipe #1", "recipe #2", "recipe #3"]));
+
+    expect(recipeWithTags[0].tags.map((e) => e.id), containsAll([2]));
+    expect(recipeWithTags[1].tags.map((e) => e.id), containsAll([2, 4, 6]));
+    expect(recipeWithTags[2].tags, isEmpty);
   });
 
   test('should filter recipes by tags', () async {
-    await _filteringRecipes([4], [2], {2: [2,4,6]});
-    await _filteringRecipes([2], [2,3], {2: [2,4,6], 3: [2]});
-    await _filteringRecipes([6], [2], {2: [2,4,6]});
-    await _filteringRecipes([6,2], [2,3], {2: [2,4,6], 3: [2]});
-    await _filteringRecipes([], [3,2,1], {1: [], 2: [2,4,6], 3: [2]});
+    await _clearDatabase();
+    await _prepareDatabaseForFiltering();
+
+    await _filteringRecipes([1, 5], [1], {1: false, 2: false});
+    await _filteringRecipes([1, 5], [], {1: true, 2: true});
+    await _filteringRecipes([1, 2], [1, 2], {1: false});
+    await _filteringRecipes([1, 2], [1], {1: true});
+    await _filteringRecipes([2, 3], [1, 2, 3], {1: false});
+    await _filteringRecipes([2, 3], [2], {1: true});
+    await _filteringRecipes([2, 5], [1, 2], {1: false, 2: false});
+    await _filteringRecipes([2, 5], [1, 2], {1: true, 2: true});
+    await _filteringRecipes([1, 2, 4], [2], {1: false, 2: false});
+    await _filteringRecipes([1, 2, 4], [], {1: true, 2: true});
+    await _filteringRecipes([2, 3, 5, 6], [1, 3], {1: false, 2: false});
+    await _filteringRecipes([2, 3, 5, 6], [], {1: true, 2: true});
+    await _filteringRecipes([8], [], {3: false});
+    await _filteringRecipes([8], [], {3: true});
   });
 }
 
-_filteringRecipes(List<int> tagIds, List<int> expectedRecipeIds,
-    Map<int, List<int>> expectedTagIdsByRecipeId) async {
+_clearDatabase() async {
+  var allRecipes = await testDatabase.getAllRecipeWithTags();
+  var allTagGroups = await testDatabase.getAllTagsWithGroups();
+
+  // remove all recipes
+  for (var recipe in allRecipes) {
+    await testDatabase.recipeDao.deleteRecipe(recipe.recipe.id);
+  }
+
+  // delete all tags
+  var tagIds = allTagGroups.map((e) => e.tags).flattened.map((e) => e.id);
+  for (var tagId in tagIds) {
+    await testDatabase.tagDao.deleteTag(tagId);
+  }
+
+  // delete tag groups
+  var tagGroupIds = allTagGroups.map((e) => e.tagGroup.id);
+  for (var tagGroupId in tagGroupIds) {
+    await testDatabase.tagGroupDao.deleteTagGroup(tagGroupId);
+  }
+}
+
+_prepareDatabaseForFiltering() async {
+  // create 3 tag groups with 3 tags each
+  var group_1 = await testDatabase.tagGroupDao.addTagGroup("group #1");
+  var group_2 = await testDatabase.tagGroupDao.addTagGroup("group #2");
+  var group_3 = await testDatabase.tagGroupDao.addTagGroup("group #3");
+
+  for (var i = 1; i <= 9; i++) {
+    var tagGroupId = -1;
+    if (i <= 3) {
+      tagGroupId = group_1.id;
+    } else if (i > 3 && i <= 6) {
+      tagGroupId = group_2.id;
+    } else {
+      tagGroupId = group_3.id;
+    }
+
+    await testDatabase.tagDao.addTag(tagGroupId, "tag #$i");
+  }
+
+  // create 3 recipes
+  await testDatabase.recipeDao.createRecipe("recipe #1", Source.memory, null, null, null, null);
+  await testDatabase.recipeDao.createRecipe("recipe #2", Source.memory, null, null, null, null);
+  await testDatabase.recipeDao.createRecipe("recipe #3", Source.memory, null, null, null, null);
+
+  var allRecipes = await testDatabase.getAllRecipeWithTags();
+  var recipe_1 = allRecipes.firstWhere((element) => element.recipe.name == "recipe #1").recipe;
+  var recipe_2 = allRecipes.firstWhere((element) => element.recipe.name == "recipe #2").recipe;
+  var recipe_3 = allRecipes.firstWhere((element) => element.recipe.name == "recipe #3").recipe;
+
+  // assign tags to recipes
+  var allTagGroupsWithTags = await testDatabase.getAllTagsWithGroups();
+  var tagsRecipe_1 = allTagGroupsWithTags.map((e) => e.tags).flattened.where((tag) => tag.label.contains(RegExp("[1,2,5,8,9]"))).map((tag) => tag.id).toList();
+  await testDatabase.recipeDao.assignTags(recipe_1.id, tagsRecipe_1);
+
+  var tagsRecipe_2 = allTagGroupsWithTags.map((e) => e.tags).flattened.where((tag) => tag.label.contains(RegExp("[2,3,4,5,7]"))).map((tag) => tag.id).toList();
+  await testDatabase.recipeDao.assignTags(recipe_2.id, tagsRecipe_2);
+
+  var tagsRecipe_3 = allTagGroupsWithTags.map((e) => e.tags).flattened.where((tag) => tag.label.contains(RegExp("[3,6]"))).map((tag) => tag.id).toList();
+  await testDatabase.recipeDao.assignTags(recipe_3.id, tagsRecipe_3);
+}
+
+_filteringRecipes(List<int> tagNumbers, List<int> expectedRecipeNumbers, Map<int, bool> tagGroupRelation) async {
+  var allTags = (await testDatabase.getAllTagsWithGroups()).map((e) => e.tags).flattened;
+  var selectedTags = tagNumbers.map((tagNumber) => allTags.firstWhere((tag) => tag.label.contains(tagNumber.toString()))).toList();
+
+  var allRecipes = (await testDatabase.getAllRecipeWithTags()).map((e) => e.recipe).toList();
+  var expectedRecipes = expectedRecipeNumbers.map((recipeNumber) => allRecipes.firstWhere((recipe) => recipe.name.contains(recipeNumber.toString()))).toList();
+  var expectedRecipeIds = expectedRecipes.map((recipe) => recipe.id).toList();
+
+  var recipeFilters = tagGroupRelation.entries.map((e) {
+    var tagGroupId = e.key;
+    var tagGroupMatchRelation = e.value;
+    var tags = selectedTags.where((tag) => tag.tagGroup == tagGroupId).map((tag) => tag.id).toList();
+    return RecipeFilter(tagGroupId, tagGroupMatchRelation, tags);
+  }).toList();
+
   // when
-  var actual = await testDatabase.filterRecipeByTags(tagIds);
+  var actual = await testDatabase.filterRecipes(recipeFilters);
 
   // then
-  expect(actual.length, expectedRecipeIds.length);
-  expect(
-      actual.map((e) => e.recipe.id), containsAllInOrder(expectedRecipeIds));
+  var selectedTagNames = selectedTags.map((tag) => tag.label).toList().join(",");
+  var expectedRecipeNames = expectedRecipes.map((recipe) => recipe.name).toList().join(",");
+  debugPrint('selected tagNames: $selectedTagNames, expected recipes: $expectedRecipeNames, tagGroupRelations: $tagGroupRelation');
 
-  expectedTagIdsByRecipeId.forEach((recipeId, tagIds) {
-    var actualRecipe =
-    actual.firstWhere((element) => element.recipe.id == recipeId);
-    var actualTagIds = actualRecipe.tags.map((e) => e.id);
-    expect(actualTagIds.length, tagIds.length);
-    if (tagIds.isNotEmpty) {
-      expect(actualTagIds, containsAllInOrder(tagIds));
-    }
-  });
+  expect(actual.length, expectedRecipeIds.length);
+  expect(actual.map((e) => e.recipe.id), containsAllInOrder(expectedRecipeIds));
 }

--- a/test/data/database_test.dart
+++ b/test/data/database_test.dart
@@ -63,24 +63,19 @@ void main() {
   test('should filter recipes by tags', () async {
     await _clearDatabase();
     await _prepareDatabaseForFiltering();
-/*
+
     await _filteringRecipes([1, 5], [1], {1: false, 2: false});
     await _filteringRecipes([1, 5], [1], {1: true, 2: true});
     await _filteringRecipes([1, 2], [1, 2], {1: false});
     await _filteringRecipes([1, 2], [1], {1: true});
     await _filteringRecipes([2, 3], [2, 1, 3], {1: false});
-
-
     await _filteringRecipes([2, 3], [2], {1: true});
     await _filteringRecipes([2, 5], [1, 2], {1: false, 2: false});
     await _filteringRecipes([2, 5], [1, 2], {1: true, 2: true});
     await _filteringRecipes([1, 2, 4], [2], {1: false, 2: false});
     await _filteringRecipes([1, 2, 4], [], {1: true, 2: true});
-
-
     await _filteringRecipes([2, 3, 5, 6], [2, 1, 3], {1: false, 2: false});
     await _filteringRecipes([2, 3, 5, 6], [], {1: true, 2: true});
-    */
     await _filteringRecipes([10], [], {3: false});
     await _filteringRecipes([10], [], {3: true});
   });

--- a/test/data/filter_test_input.dart
+++ b/test/data/filter_test_input.dart
@@ -1,0 +1,7 @@
+class FilterTestInput {
+  final List<int> selectedTags;
+  final List<int> expectedRecipeIds;
+  final Map<int, bool> tagGroupMatchRelations;
+
+  FilterTestInput(this.selectedTags, this.expectedRecipeIds, this.tagGroupMatchRelations);
+}


### PR DESCRIPTION
@p-saurer filtering of recipes is now changed from applying all filters OR-connected to AND-connected - this fixes the use-case 'Vegetarian' and 'Lunch' showing non-veggie recipes.
There is also an option to change filter-relation from AND- to OR-connected per tag-group (but filters between tag-group are still AND-connected and cannot be changed).
Although that's a greater experience for the user it can now produce empty results - let's talk next meeting what to about this